### PR TITLE
Questions for usage with Emulsify

### DIFF
--- a/src/TwigExtension/ExtensionLoader.php
+++ b/src/TwigExtension/ExtensionLoader.php
@@ -48,16 +48,18 @@ class ExtensionLoader {
     $themeLocation = drupal_get_path('theme', $theme);
     $fullPath = DRUPAL_ROOT . '/' . $themeLocation . '/' . 'pattern-lab/source/_twig-components/';
 
-    $fullPathAlt = DRUPAL_ROOT . '/' . $themeLocation . '/' . 'source/_twig-components/';
+    $fullPathAlt = DRUPAL_ROOT . '/' . $themeLocation . '/' . 'components/_twig-components/';
 
     if (file_exists($fullPathAlt)){
       $fullPath = $fullPathAlt;
     }
 
     foreach (scandir($fullPath . $type) as $file) {
-      if ($file[0] != '.' && $file[0] != '_') {
-        // print_r($file);
-        static::load($type, $fullPath . $type . '/' . $file);
+      $fileInfo = pathinfo($file);
+      if ($fileInfo['extension'] === 'php') {
+        if ($file[0] != '.' && $file[0] != '_' && substr($file, 0, 2) != 'd_') {
+          static::load($type, $fullPath . $type . '/' . $file);
+        }
       }
     }
   }

--- a/src/TwigExtension/ExtensionLoader.php
+++ b/src/TwigExtension/ExtensionLoader.php
@@ -57,7 +57,7 @@ class ExtensionLoader {
     foreach (scandir($fullPath . $type) as $file) {
       $fileInfo = pathinfo($file);
       if ($fileInfo['extension'] === 'php') {
-        if ($file[0] != '.' && $file[0] != '_' && substr($file, 0, 2) != 'd_') {
+        if ($file[0] != '.' && $file[0] != '_' && substr($file, 0, 3) != 'pl_') {
           static::load($type, $fullPath . $type . '/' . $file);
         }
       }

--- a/src/TwigExtension/ExtensionLoader.php
+++ b/src/TwigExtension/ExtensionLoader.php
@@ -46,19 +46,18 @@ class ExtensionLoader {
   static protected function loadAll($type) {
     $theme = \Drupal::config('system.theme')->get('default');
     $themeLocation = drupal_get_path('theme', $theme);
-    $fullPath = DRUPAL_ROOT . '/' . $themeLocation . '/' . 'pattern-lab/source/_twig-components/';
+    $themePath = DRUPAL_ROOT . '/' . $themeLocation . '/';
 
-    $fullPathAlt = DRUPAL_ROOT . '/' . $themeLocation . '/' . 'components/_twig-components/';
+    $extensionPaths = glob($themePath . '*/_twig-components/');
 
-    if (file_exists($fullPathAlt)){
-      $fullPath = $fullPathAlt;
-    }
-
-    foreach (scandir($fullPath . $type) as $file) {
-      $fileInfo = pathinfo($file);
-      if ($fileInfo['extension'] === 'php') {
-        if ($file[0] != '.' && $file[0] != '_' && substr($file, 0, 3) != 'pl_') {
-          static::load($type, $fullPath . $type . '/' . $file);
+    foreach ($extensionPaths as $extensionPath) {
+      $fullPath = $extensionPath;
+      foreach (scandir($fullPath . $type) as $file) {
+        $fileInfo = pathinfo($file);
+        if ($fileInfo['extension'] === 'php') {
+          if ($file[0] != '.' && $file[0] != '_' && substr($file, 0, 3) != 'pl_') {
+            static::load($type, $fullPath . $type . '/' . $file);
+          }
         }
       }
     }


### PR DESCRIPTION
I don't think this will be an accept as-is kinda PR, but I thought I'd create it as a conversation-starter. I made a couple of tweaks so that we could use it with Emulsify, and specifically [a new plugin we created](https://github.com/fourkitchens/emulsify/pull/78).

I ran into errors when simply using the `if (!class_exists('Drupal')) {` wrapper - you can see them if you install Emulsify as a theme and turn on this module. So, I added the namespace `pl_` to the list of ignored file syntax.

~~Also, we needed to tweak the directory path as well since we use `components` instead of the standard PL name `source`.~~ We've made the path search a glob to cover multiple naming conventions.

What do you think about these changes? I'm very open to different approaches, and would love to get them into this repo instead of running a fork (I just did that so we could test the PR on our end).