### PR TITLE
Remove use include from same namespace

### DIFF
--- a/src/TwigExtension/ExtensionAdapter.php
+++ b/src/TwigExtension/ExtensionAdapter.php
@@ -1,7 +1,5 @@
 <?php
 
-use Drupal\unified_twig_ext\TwigExtension\ExtensionLoader;
-
 namespace Drupal\unified_twig_ext\TwigExtension;
 
 /**


### PR DESCRIPTION
The file it includes is in the same namespace, so it is not necessary and it makes PHPStorm unhappy :)