### PR TITLE
Fixes ExtensionLoader::loadAll method to find all Twig extensions as expected

### DIFF
--- a/src/TwigExtension/ExtensionAdapter.php
+++ b/src/TwigExtension/ExtensionAdapter.php
@@ -1,8 +1,8 @@
 <?php
 
-use Drupal\unified_twig_ext\TwigExtension\ExtensionLoader;
-
 namespace Drupal\unified_twig_ext\TwigExtension;
+
+use Drupal\unified_twig_ext\TwigExtension\ExtensionLoader;
 
 /**
  * Adapts pattern-lab extensions to Drupal.

--- a/src/TwigExtension/ExtensionLoader.php
+++ b/src/TwigExtension/ExtensionLoader.php
@@ -81,11 +81,11 @@ class ExtensionLoader {
     include $file;
     switch ($type) {
       case 'filters':
-        self::$objects['filters'][] = $filter;
+        self::$objects['filters'][] = $file;
         break;
 
       case 'functions':
-        self::$objects['functions'][] = $function;
+        self::$objects['functions'][] = $file;
         break;
 
       case 'tags':

--- a/unified_twig_ext.services.yml
+++ b/unified_twig_ext.services.yml
@@ -1,5 +1,5 @@
 services:
-  newcity_twig.twig_extension:
+  unified_twig_ext.twig_extension:
     arguments: ['@renderer']
     class: Drupal\unified_twig_ext\TwigExtension\ExtensionAdapter
     tags:


### PR DESCRIPTION
The `glob()` function in `ExtensionLoader::loadAll` does not adequately account for nested `_twig-components` directories within a given Pattern Lab implementation. This PR refactors that method to allow for deeper nested `_twig-components` directories. PR also includes minor PHP Code Sniffer errors.