### PR TITLE
Load extensions from active theme not the default theme.

### DIFF
--- a/src/TwigExtension/ExtensionLoader.php
+++ b/src/TwigExtension/ExtensionLoader.php
@@ -44,8 +44,7 @@ class ExtensionLoader {
    *   The type to load all plugins for.
    */
   static protected function loadAll($type) {
-    $theme = \Drupal::config('system.theme')->get('default');
-    $themeLocation = drupal_get_path('theme', $theme);
+    $themeLocation = \Drupal::service('theme.manager')->getActiveTheme()->getPath();
     $themePath = DRUPAL_ROOT . '/' . $themeLocation . '/';
 
     $extensionPaths = glob($themePath . '*/_twig-components/');


### PR DESCRIPTION
If the default theme does not use pattern-lab and a module sets the active theme via ThemeNegotiatorInterface to use a pattern lab them then it fails due to attempting to locate the extensions in the default theme not the new active theme.